### PR TITLE
feat: Add useScheduledTime option to set notification timestamp to sc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can create an AlarmNotification using the below properties:
 * <b>badge</b> - (Optional) (boolean) Sets whether notifications posted to this channel can appear as application icon badges in a Launcher.
 * <b>badegeIconType</b> - (Optional) (const) Sets which icon to display as a badge for this notification.
 * <b>when</b> - (Optional) (long) Difference to now in sec. Default is 0
+* <b>useScheduledTime</b> - (Optional) (boolean) If true, sets the notification timestamp to the scheduled alarm time instead of the time when the alarm fires. This is useful for showing users when an alarm was supposed to fire. Default is false.
 * <b>ongoing</b> - (Optional) (boolean) false: user cannot swipe out
 * <b>group</b> - (OPtional) (String) diffent for every notification if you want an extra strip.
 * <b>showWhen</b>  - (Optional) (boolean)
@@ -252,6 +253,16 @@ var ew2 = Ti.UI.createAlertDialog({
 	buttonNames:[Ti.Android.currentActivity.getString(Ti.Android.R.string.ok)]
 });
  ew2.show();
+
+//Below is an example using useScheduledTime to set the notification timestamp to the scheduled time
+//This is useful for showing users when an alarm was supposed to fire
+alarmManager.addAlarmNotification({
+	requestCode:requestCode + 1,
+	minute: 5, //Set the alarm to go off in 5 minutes
+	contentTitle:'Scheduled Alarm', //Set the title of the Notification that will appear
+	contentText:'This notification shows the scheduled time', //Set the body of the notification that will appear
+	useScheduledTime: true //The notification timestamp will show the time the alarm was scheduled for, not when it fires
+});
 
 //Cancel our Notification based Alarms
 alarmManager.cancelAlarmNotification(requestCode);

--- a/example/app.js
+++ b/example/app.js
@@ -197,6 +197,27 @@ btn8.addEventListener('click', function(e) {
 });
 
 
+var btn8b = Ti.UI.createButton({
+	title: "Alarm with Scheduled Timestamp",
+	height: 50
+});
+win.add(btn8b);
+btn8b.addEventListener('click', function(e) {
+	alarmManager.addAlarmNotification({
+		requestCode: 45, //Request ID used to identify a specific alarm
+		minute: 1, //Set the number of minutes until the alarm should go off
+		contentTitle: 'Scheduled Time Example', //Set the title of the Notification that will appear
+		contentText: 'This notification shows the scheduled time', //Set the body of the notification that will appear
+		useScheduledTime: true //Set the notification timestamp to the scheduled alarm time
+	});
+	var ew = Ti.UI.createAlertDialog({
+		title: 'Info',
+		message: "Alarm set for 1 minute. The notification will show the scheduled time, not the fire time.",
+		buttonNames: [Ti.Android.currentActivity.getString(Ti.Android.R.string.ok)]
+	});
+	ew.show();
+});
+
 var btn9 = Ti.UI.createButton({
 	title: "Alarm '43' & Notify Cancel",
 	height: 50

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.4.0
+version: 4.4.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: This module provides Titanium access to Androids Alarm Manager functionality

--- a/src/bencoding/alarmmanager/AlarmManagerProxy.java
+++ b/src/bencoding/alarmmanager/AlarmManagerProxy.java
@@ -98,7 +98,7 @@ public class AlarmManagerProxy extends KrollProxy {
         return cal;
     }
 
-    private Intent createAlarmNotifyIntent(KrollDict args, int requestCode) {
+    private Intent createAlarmNotifyIntent(KrollDict args, int requestCode, long scheduledTime) {
         utils.debugLog("createAlarmNotifyIntent::requestCode=" + requestCode);
         int notificationIcon = 0;
         String contentTitle = "";
@@ -128,7 +128,10 @@ public class AlarmManagerProxy extends KrollProxy {
         if (args.containsKeyAndNotNull("importance")) {
             importance = args.getInt("importance");
         }
-        if (args.containsKeyAndNotNull("when")) {
+        if (args.containsKeyAndNotNull("useScheduledTime") && args.getBoolean("useScheduledTime")) {
+            when = scheduledTime;
+            utils.debugLog("Using scheduled time for notification timestamp: " + when);
+        } else if (args.containsKeyAndNotNull("when")) {
             when = 1000L * args.getInt("when") + System.currentTimeMillis();
         }
         if (args.containsKeyAndNotNull("group")) {
@@ -269,7 +272,7 @@ public class AlarmManagerProxy extends KrollProxy {
 
         // Create the Alarm Manager
         AlarmManager am = (AlarmManager) ctx.getSystemService(TiApplication.ALARM_SERVICE);
-        Intent intent = createAlarmNotifyIntent(args, intentRequestCode);
+        Intent intent = createAlarmNotifyIntent(args, intentRequestCode, 0);
         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
         PendingIntent sender = PendingIntent.getBroadcast(ctx,
                 intentRequestCode, intent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
@@ -300,7 +303,7 @@ public class AlarmManagerProxy extends KrollProxy {
 
         // Create the Alarm Manager
         AlarmManager am = (AlarmManager) ctx.getSystemService(TiApplication.ALARM_SERVICE);
-        Intent intent = createAlarmNotifyIntent(args, intentRequestCode);
+        Intent intent = createAlarmNotifyIntent(args, intentRequestCode, 0);
         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
 
         boolean alarmUp = (PendingIntent.getBroadcast(ctx, intentRequestCode, intent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_NO_CREATE) != null);
@@ -400,7 +403,7 @@ public class AlarmManagerProxy extends KrollProxy {
 
         // Create the Alarm Manager
         AlarmManager am = (AlarmManager) ctx.getSystemService(TiApplication.ALARM_SERVICE);
-        Intent intent = createAlarmNotifyIntent(args, requestCode);
+        Intent intent = createAlarmNotifyIntent(args, requestCode, calendar.getTimeInMillis());
         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
         PendingIntent sender = PendingIntent.getBroadcast(ctx,
                 requestCode, intent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);


### PR DESCRIPTION
…heduled time (v4.4.1)

- Added useScheduledTime parameter to addAlarmNotification method
- When enabled, notification timestamp shows scheduled alarm time instead of fire time
- Updated createAlarmNotifyIntent to accept and use scheduledTime parameter
- Added documentation for new feature in README.md
- Added example usage in example/app.js
- Bumped version to 4.4.1

This feature is useful for:
- Showing users when an event was supposed to happen
- Maintaining consistent timestamps for recurring alarms
- Better UX when alarms fire with system delays